### PR TITLE
ENH: Prefer std:: over vcl versions.

### DIFF
--- a/include/itkLabelSetMorphBaseImageFilter.hxx
+++ b/include/itkLabelSetMorphBaseImageFilter.hxx
@@ -99,9 +99,9 @@ LabelSetMorphBaseImageFilter< TInputImage, doDilate, TOutputImage >
   double range = static_cast< double >( requestedRegionSize[splitAxis] );
 
   unsigned int valuesPerThread =
-    static_cast< unsigned int >( vcl_ceil( range / static_cast< double >( num ) ) );
+    static_cast< unsigned int >( std::ceil( range / static_cast< double >( num ) ) );
   unsigned int maxThreadIdUsed =
-    static_cast< unsigned int >( vcl_ceil( range / static_cast< double >( valuesPerThread ) ) ) - 1;
+    static_cast< unsigned int >( std::ceil( range / static_cast< double >( valuesPerThread ) ) ) - 1;
 
   // Split the region
   if ( i < maxThreadIdUsed )


### PR DESCRIPTION
The vcl_* definitions can now be greatly simplified.
After removing specializations for early non-conformant
c++ compilers the end result was that only the
std:: version of the functions could ever be
used by the compiler.