### PR TITLE
STYLE: Prefer error checked std::sto[id] over ato[if].

### DIFF
--- a/test/itkLabelSetDilateTest.cxx
+++ b/test/itkLabelSetDilateTest.cxx
@@ -89,10 +89,10 @@ int itkLabelSetDilateTest(int argc, char *argv[])
   switch ( dim1 )
     {
     case 2:
-      status = doDilate< unsigned char, 2 >( argv[1], argv[3], atoi(argv[2]) );
+      status = doDilate< unsigned char, 2 >( argv[1], argv[3], std::stoi(argv[2]) );
       break;
     case 3:
-      status = doDilate< unsigned char, 3 >( argv[1], argv[3], atoi(argv[2]) );
+      status = doDilate< unsigned char, 3 >( argv[1], argv[3], std::stoi(argv[2]) );
       break;
     default:
       std::cerr << "Unsupported dimension" << std::endl;

--- a/test/itkLabelSetErodeTest.cxx
+++ b/test/itkLabelSetErodeTest.cxx
@@ -90,10 +90,10 @@ int itkLabelSetErodeTest(int argc, char *argv[])
   switch ( dim1 )
     {
     case 2:
-      status = doErode< unsigned char, 2 >( argv[1], argv[3], atoi(argv[2]) );
+      status = doErode< unsigned char, 2 >( argv[1], argv[3], std::stoi(argv[2]) );
       break;
     case 3:
-      status = doErode< unsigned char, 3 >( argv[1], argv[3], atoi(argv[2]) );
+      status = doErode< unsigned char, 3 >( argv[1], argv[3], std::stoi(argv[2]) );
       break;
     default:
       std::cerr << "Unsupported dimension" << std::endl;


### PR DESCRIPTION
STYLE: Prefer error checked std::sto[id] over ato[if].

The `ato[if]` functions do not provide mechanisms for distinguishing
between `0` and the error condition where the input can not be converted.

`std::sto[id]` provides exception handling and detects when an invalid
string attempts to be converted to an [integer|double].

`ato[if]()`
 - **Con**: No error handling.
 - **Con**: Handle neither hexadecimal nor octal.

The use of `ato[if]` in code can cause it to be subtly broken.
`ato[if]` makes two very big assumptions indeed:
 - The string represents an integer/floating point value.
 - The integer can fit into an int.

In agreement with:
http://review.source.kitware.com/#/c/23738/