### PR TITLE
ENH: Allow building outside ITK.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,2 +1,9 @@
-PROJECT(LabelErodeDilate)
-itk_module_impl()
+project(LabelErodeDilate)
+
+if(NOT ITK_SOURCE_DIR)
+  find_package(ITK REQUIRED)
+  list(APPEND CMAKE_MODULE_PATH ${ITK_CMAKE_DIR})
+  include(ITKModuleExternal)
+else()
+  itk_module_impl()
+endif()


### PR DESCRIPTION
Modify the `CMakeLists.txt` file to allow building the module outside the
ITK source tree.